### PR TITLE
初步完成RESTful服务端重构

### DIFF
--- a/doc/api/miac-server-api.yaml
+++ b/doc/api/miac-server-api.yaml
@@ -41,12 +41,44 @@ paths:
       parameters:
         - name: "title"
           in: "formData"
+          required: true
           type: "string"
+        - name: "description"
+          in: "formData"
+          required: true
+          type: "string"
+        - name: "attachment"
+          in: "formData"
+          type: "file"
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
       x-swagger-router-controller: "homework"
-  /hw/{title}:
+  /hw/{hwId}:
+    get:
+      tags:
+      - "homework"
+      summary: "Get homework by homework id"
+      description: ""
+      operationId: "getOneHomework"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "hwId"
+        in: "path"
+        description: "Homework id"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "Success"
+          # schema:
+          #   $ref: "#/definitions/Homework"
+        400:
+          description: "Invalid homework id"
+        404:
+          description: "Homework not found"
+      x-swagger-router-controller: "homework"
     post:
       tags:
       - "homework"
@@ -54,37 +86,49 @@ paths:
       description: ""
       operationId: "postHomework"
       parameters:
-        - name: "title"
+        - name: "hwId"
           in: "path"
-          description: "title of homework"
+          description: "homework id"
           required: true
           type: "string"
-        - name: "file"
+        - name: "submission"
           in: "formData"
           required: true
           type: "file"
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid homework id"
+        403:
+          description: "Homework not assigned to current user"
+        404:
+          description: "Homework not found"
       x-swagger-router-controller: "homework"
     delete:
       tags:
       - "homework"
       - "administrator"
-      summary: "Delete a homework by title"
+      summary: "Delete a homework by homework id"
       description: "only administrator can delete a homework"
       operationId: "deleteHomework"
       parameters:
-        - name: "title"
+        - name: "hwId"
           in: "path"
-          description: "title of homework"
+          description: "homework id"
           required: true
           type: "string"
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid homework id"
+        403:
+          description: "Homework not assigned to commented user"
+        404:
+          description: "Homework not found"
       x-swagger-router-controller: "homework"
-  /hw/{title}/comment/{userId}:
+  /hw/{hwId}/comment/{userId}:
     post:
       tags:
       - "homework"
@@ -93,23 +137,28 @@ paths:
       produces:
       - "application/json"
       parameters:
-        - name: "title"
+        - name: "hwId"
           in: "path"
-          description: "title of homework"
+          description: "homework id"
           required: true
           type: "string"
         - name: "userId"
           in: "path"
-          description: "id of administrator"
+          description: "club member id"
           required: true
           type: "string"
-        - name: "text"
-          in: "formData"
+        - name: "content"
+          in: "body"
+          description: "comment content"
           required: true
           type: "string"
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid homework/user id"
+        404:
+          description: "Homework not found"
       x-swagger-router-controller: "homework"
   /article:
     post:
@@ -125,13 +174,15 @@ paths:
       parameters:
       - in: "body"
         name: "body"
-        description: "article object that needs to be added"
+        description: "Article object"
         required: true
         schema:
           $ref: "#/definitions/Article"
       responses:
-        405:
-          description: "Invalid input"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid fields"
       x-swagger-router-controller: "article"
   /article/{articleId}:
     get:
@@ -145,23 +196,23 @@ paths:
       parameters:
       - name: "articleId"
         in: "path"
-        description: "ID of article to return"
+        description: "article id"
         required: true
         type: "string"
       responses:
         200:
-          description: "successful operation"
+          description: "Success"
           schema:
             $ref: "#/definitions/Article"
         400:
-          description: "Invalid ID supplied"
+          description: "Invalid article id"
         404:
-          description: "article not found"
+          description: "Article not found"
       x-swagger-router-controller: "article"
     put:
       tags:
       - "article"
-      summary: "Updates a article"
+      summary: "Update an article"
       description: "only the author of the article or the administrator can update it"
       operationId: "updateArticle"
       produces:
@@ -169,18 +220,22 @@ paths:
       parameters:
       - name: "articleId"
         in: "path"
-        description: "ID of article that needs to be updated"
+        description: "Article id"
         required: true
         type: "string"
       - in: "body"
         name: "body"
-        description: "Updated user object"
+        description: "Updated article object"
         required: true
         schema:
           $ref: "#/definitions/Article"
       responses:
-        405:
-          description: "Invalid input"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid fields"
+        404:
+          description: "Article not found"
       x-swagger-router-controller: "article"
     delete:
       tags:
@@ -197,10 +252,12 @@ paths:
         required: true
         type: "string"
       responses:
+        200:
+          description: "Success"
         400:
-          description: "Invalid ID supplied"
+          description: "Invalid article id"
         404:
-          description: "article not found"
+          description: "Article not found"
       x-swagger-router-controller: "article"
   /article/{articleId}/comment:
     post:
@@ -217,11 +274,18 @@ paths:
         description: "article id"
         required: true
         type: "string"
+      - name: "content"
+        in: "body"
+        description: "comment content"
+        required: true
+        type: "string"
       responses:
+        200:
+          description: "Success"
         400:
-          description: "Invalid ID supplied"
+          description: "Invalid article id"
         404:
-          description: "article not found"
+          description: "Article not found"
       x-swagger-router-controller: "article"
   /user:
     post:
@@ -241,8 +305,12 @@ paths:
         schema:
           $ref: "#/definitions/User"
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
+        400:
+          description: "Invalid fields"
+        403:
+          description: "Permission denied"
       x-swagger-router-controller: "User"
   /user/login:
     get:
@@ -254,7 +322,7 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "id"
+      - name: "username"
         in: "query"
         description: "The user name for login"
         required: true
@@ -266,11 +334,11 @@ paths:
         type: "string"
       responses:
         200:
-          description: "successful operation"
-          schema:
-            type: "string"
+          description: "Success"
         400:
           description: "Invalid username/password supplied"
+        404:
+          description: "User not found"
       x-swagger-router-controller: "User"
   /user/logout:
     get:
@@ -283,10 +351,12 @@ paths:
       - "application/json"
       parameters: []
       responses:
-        default:
-          description: "successful operation"
+        200:
+          description: "Success"
+        401:
+          description: "Not authorized"
       x-swagger-router-controller: "User"
-  /user/{id}:
+  /user/{userId}:
     get:
       tags:
       - "user"
@@ -296,18 +366,18 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "id"
+      - name: "userId"
         in: "path"
-        description: "The name that needs to be fetched."
+        description: "User id"
         required: true
         type: "string"
       responses:
         200:
-          description: "successful operation"
+          description: "Success"
           schema:
             $ref: "#/definitions/User"
         400:
-          description: "Invalid username supplied"
+          description: "Invalid user id"
         404:
           description: "User not found"
       x-swagger-router-controller: "User"
@@ -320,7 +390,7 @@ paths:
       produces:
       - "application/json"
       parameters:
-      - name: "id"
+      - name: "userId"
         in: "path"
         description: "user that need to be updated"
         required: true
@@ -332,8 +402,12 @@ paths:
         schema:
           $ref: "#/definitions/User"
       responses:
+        200:
+          description: "Success/User not modified"
         400:
-          description: "Invalid user supplied"
+          description: "Invalid user id/fields"
+        403:
+          description: "Not user himself"
         404:
           description: "User not found"
       x-swagger-router-controller: "User"
@@ -341,23 +415,23 @@ definitions:
   User:
     type: "object"
     properties:
-      id:
-        type: "string"
-      nickname:
+      username:
         type: "string"
       password:
+        type: "string"
+      nickname:
         type: "string"
       email:
         type: "string"
       github:
         type: "string"
-      permission:
-        type: "integer"
-        format: "int32"
+      # permission:
+      #   type: "integer"
+      #   format: "int32"
   Article:
     type: "object"
     properties:
       title:
         type: "string"
-      text:
+      content:
         type: "string"

--- a/server/database.md
+++ b/server/database.md
@@ -5,36 +5,62 @@
 Field        | Type          | Notes
 ------------ | ------------- | ------------
 _id          | String        | id in datebase (auto generated)
-id           | String        | login ID
+username     | String        | login username [unique] * (id -> username)
 password     | String        | password
 permission   | Number        | permission
 nickname     | String        | nickname
 github       | String        | Github link
 headimg      | String        | link of head portrait
 email        | String        | E-mail
-hw           | Array         | Homeworks
-hw.title     | String        | Homework's title
-hw.file      | String        | path to the file
-hw.comment   | Object        | comments
-hw.comment.text | String     | comment's content
-hw.comment.author | String   | who comment
 deleted      | Boolean       | is deleted
+homeworks    | Array [oneHw] | Homeworks *
+oneHw.hwId   | ObjectId      | Homework's id *
+oneHw.subId  | ObjectId      | Latest submission's id *
+
+## Comment (分为 Article Comment、Submission Comment 等 collection，但可以复用同一套逻辑)
+
+Field        | Type             | Notes
+------------ | ---------------- | ------------
+_id          | String           | id in datebase (auto generated)
+author       | String           | username of the author
+content      | String           | Comment's content
+date         | Date             | When the comment is made
+isFeedback   | Boolean          | is feedback (only in collection ``Submission Comment``)
+deleted      | Boolean          | is deleted
 
 ## Homework
 
-Field        | Type          | Notes
------------- | ------------- | ------------
-title        | String        | Homework's title [unique]
-deleted      | Boolean       | is deleted
+Field        | Type             | Notes
+------------ | ---------------- | ------------
+_id          | String           | id in datebase (auto generated)
+title        | String           | Homework's title
+description  | String           | Homework's description (+)
+begindate    | Date             | When the homework begins (nullable) (+)
+enddate      | Date             | When the homework is due (nullable) (+)
+comments     | Array [ObjectId] | ids of comments on the homework (+) (需要？)
+deleted      | Boolean          | is deleted
 
 ## Article
 
-Field          | Type        | Notes
--------------- | ----------- | ------------
-_id            | String      | id in datebase (auto generated)
-title          | String      | title
-text           | String      | content
-date           | Date        | date
-userid         | String      | who post this article
-username       | String      | show in front end
-deleted        | Boolean     | is deleted
+Field          | Type              | Notes
+-------------- | ----------------- | ------------
+_id            | String            | id in datebase (auto generated)
+title          | String            | title
+content        | String            | content * (text -> content)
+date           | Date              | date
+userId         | String            | who posts this article * (userid -> userId)
+username       | String            | show in front end (这个是发文章时可以设置的？)
+comments       | Array [ObjectId]  | ids of comments on the homework (+)
+deleted        | Boolean           | is deleted
+
+## Submission
+
+Field        | Type             | Notes
+------------ | ---------------- | ------------
+_id          | String           | id in datebase (auto generated)
+hwId         | ObjectId         | Homework's id that the submission is belongs to
+author       | String           | username of the author
+date         | Date             | When the submission is submitted
+comments     | Array [ObjectId] | ids of comments on the submission (by all)
+feedbacks    | Array [ObjectId] | ids of feedbacks on the submission (by all)
+deleted      | Boolean          | is deleted

--- a/server/database.md
+++ b/server/database.md
@@ -40,7 +40,7 @@ title        | String           | homework's title
 description  | String           | homework's description (+)
 beginTime    | Date             | when the homework begins (nullable) (+)
 endTime      | Date             | when the homework is due (nullable) (+)
-attachments  | Array [String]   | filename of attachments
+attachments  | Array [ObjectId] | ids of attachments
 comments     | Array [ObjectId] | ids of comments on the homework (+) (需要？)
 deleted      | Boolean          | is deleted
 
@@ -67,7 +67,7 @@ hwId         | ObjectId         | homework's id that the submission is belongs t
 author       | ObjectId         | the author's id
 createdTime  | Date             | when the submission is created
 updatedTime  | Date             | when the submission is updated
-filename     | String           | filename of the submission
+fileId       | ObjectId         | submission file id
 comments     | Array [ObjectId] | ids of comments on the submission (by all)
 feedbacks    | Array [ObjectId] | ids of feedbacks on the submission (by all)
 deleted      | Boolean          | is deleted

--- a/server/database.md
+++ b/server/database.md
@@ -10,33 +10,37 @@ password     | String        | password
 permission   | Number        | permission
 nickname     | String        | nickname
 github       | String        | Github link
-headimg      | String        | link of head portrait
 email        | String        | E-mail
 deleted      | Boolean       | is deleted
-homeworks    | Array [oneHw] | Homeworks *
-oneHw.hwId   | ObjectId      | Homework's id *
-oneHw.subId  | ObjectId      | Latest submission's id *
+homeworks    | Array [oneHw] | homeworks *
+oneHw.hwId   | ObjectId      | homework's id *
+oneHw.subId  | ObjectId      | latest submission's id *
 
-## Comment (分为 Article Comment、Submission Comment 等 collection，但可以复用同一套逻辑)
+## Comment
 
-Field        | Type             | Notes
------------- | ---------------- | ------------
-_id          | String           | id in datebase (auto generated)
-author       | String           | username of the author
-content      | String           | Comment's content
-date         | Date             | When the comment is made
-isFeedback   | Boolean          | is feedback (only in collection ``Submission Comment``)
-deleted      | Boolean          | is deleted
+Field              | Type             | Notes
+------------------ | ---------------- | ------------
+_id                | String           | id in datebase (auto generated)
+author             | ObjectId         | the author's id
+content            | String           | comment's content
+createdTime        | Date             | when the comment is created
+updatedTime        | Date             | when the comment is updated
+type               | String           | 'article', 'homework', 'submission'
+ownerId            | ObjectId         | where the comment is made (hwId/articleId/subId)
+details            | Object           | comment type-specific details
+details.isFeedback | Boolean          | whether the comment is a feedback made by administrators
+deleted            | Boolean          | is deleted
 
 ## Homework
 
 Field        | Type             | Notes
 ------------ | ---------------- | ------------
 _id          | String           | id in datebase (auto generated)
-title        | String           | Homework's title
-description  | String           | Homework's description (+)
-begindate    | Date             | When the homework begins (nullable) (+)
-enddate      | Date             | When the homework is due (nullable) (+)
+title        | String           | homework's title
+description  | String           | homework's description (+)
+beginTime    | Date             | when the homework begins (nullable) (+)
+endTime      | Date             | when the homework is due (nullable) (+)
+attachments  | Array [String]   | filename of attachments
 comments     | Array [ObjectId] | ids of comments on the homework (+) (需要？)
 deleted      | Boolean          | is deleted
 
@@ -47,9 +51,10 @@ Field          | Type              | Notes
 _id            | String            | id in datebase (auto generated)
 title          | String            | title
 content        | String            | content * (text -> content)
-date           | Date              | date
-userId         | String            | who posts this article * (userid -> userId)
-username       | String            | show in front end (这个是发文章时可以设置的？)
+createdTime    | Date              | when the article is created
+updatedTime    | Date              | when the article is updated
+author         | ObjectId          | who posts this article * (userid -> userId)
+?username      | String            | show in front end (这个是发文章时可以设置的？)
 comments       | Array [ObjectId]  | ids of comments on the homework (+)
 deleted        | Boolean           | is deleted
 
@@ -58,9 +63,11 @@ deleted        | Boolean           | is deleted
 Field        | Type             | Notes
 ------------ | ---------------- | ------------
 _id          | String           | id in datebase (auto generated)
-hwId         | ObjectId         | Homework's id that the submission is belongs to
-author       | String           | username of the author
-date         | Date             | When the submission is submitted
+hwId         | ObjectId         | homework's id that the submission is belongs to
+author       | ObjectId         | the author's id
+createdTime  | Date             | when the submission is created
+updatedTime  | Date             | when the submission is updated
+filename     | String           | filename of the submission
 comments     | Array [ObjectId] | ids of comments on the submission (by all)
 feedbacks    | Array [ObjectId] | ids of feedbacks on the submission (by all)
 deleted      | Boolean          | is deleted

--- a/server/package.json
+++ b/server/package.json
@@ -22,11 +22,13 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "bulk-require": "^1.0.0",
+    "gridfs-stream": "^1.1.1",
     "koa": "^2.0.0-alpha.5",
     "koa-bodyparser": "^3.2.0",
     "koa-compose": "^3.1.0",
     "koa-convert": "^1.2.0",
     "koa-generic-session": "^1.11.5",
+    "koa-multer": "^1.0.1",
     "koa-router": "^7.0.1",
     "koa-session-mongoose": "^1.0.0",
     "koa-static": "^3.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "bulk-require": "^1.0.0",
-    "gridfs-stream": "^1.1.1",
     "koa": "^2.0.0-alpha.5",
     "koa-bodyparser": "^3.2.0",
     "koa-compose": "^3.1.0",
@@ -35,6 +34,7 @@
     "lodash": "^4.17.4",
     "log4js": "^0.6.38",
     "mongoose": "^4.5.9",
+    "mongoose-gridfs": "^0.1.0",
     "nodemon": "^1.10.0"
   }
 }

--- a/server/src/controllers/article.js
+++ b/server/src/controllers/article.js
@@ -1,6 +1,11 @@
 const Router = require('koa-router');
 const _ = require('lodash');
-const { sendData, handleError, recordAction } = require('../utils');
+const {
+  sendData,
+  handleError,
+  recordAction,
+  isValidObjectId,
+} = require('../utils');
 const { debug, error } = require('../utils/logger');
 const articleService = require('../service/article');
 const authService = require('../service/authorization');
@@ -10,35 +15,140 @@ const articleRtr = new Router({
 });
 
 articleRtr.post('/', authService.requireLogin, createOneArticle);
-articleRtr.param('articleId', parseArticle);
-articleRtr.delete('/:articleId', authService.requireLogin, deleteOneArticle);
-articleRtr.get('/:articleId', getOneArticle);
-articleRtr.put('/:articleId', authService.requireLogin, updateOneArticle);
-articleRtr.post('/:articleId/comment', authService.requireLogin, commentOnArticle);
+articleRtr.param('_id', parseArticle);
+articleRtr.delete('/:_id', authService.requireLogin, deleteOneArticle);
+articleRtr.get('/:_id', getOneArticle);
+articleRtr.put('/:_id', authService.requireLogin, updateOneArticle);
+articleRtr.post('/:_id/comment', authService.requireLogin, commentOnArticle);
 
-async function parseArticle(title, ctx, next) {
-  // TODO
+async function parseArticle(_id, ctx, next) {
+  let article = null;
+  if (!isValidObjectId(_id)) {
+    return sendData(ctx, {}, 'INVALID_VALUE', 'Invalid article id', 400);
+  }
+  try {
+    article = await articleService.getOne(_id);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_QUERY_ERROR');
+  }
+  if (article === null) {
+    return sendData(ctx, {}, 'NOT_FOUND', 'Article not found', 404);
+  }
+  ctx.paramsData.article = article._doc;
   await next();
 }
 
-async function createOneArticle(ctx) {
+async function isValidNewArticle(ctx, newHw) {
   // TODO
+  return true;
+}
+
+async function createOneArticle(ctx) {
+  const { body } = ctx.request;
+  const { user: { _id: author } } = ctx.paramsData;
+  if (!await isValidNewArticle(ctx, body)) return;
+  Object.assign(body, { author });
+
+  let _doc = null;
+  try {
+    _doc = await articleService.createOne(body);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  const { title } = body;
+  const dataToSend = { _id: String(_doc._id), title };
+  recordAction(ctx, `发表文章 ${title} (_id = ${_doc._id})`);
+  return sendData(ctx, dataToSend, 'OK', `Created article ${title} successfully`);
 }
 
 async function deleteOneArticle(ctx) {
-  // TODO
+  const {
+    user: { _id: curUserId, permission },
+    article: { _id, title, author },
+  } = ctx.paramsData;
+
+  if (String(curUserId) !== String(author) && permission !== 2) {
+    return sendData(ctx, {}, 'NO_PERMISSION', "You cannot delete others' article", 403);
+  }
+  try {
+    await articleService.deleteOne(_id);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  recordAction(ctx, `删除文章 ${title} (_id = ${_id})`);
+  return sendData(ctx, {}, 'OK', `Deleted homework ${title} successfully`);
 }
 
+const articleAvailableProps = [
+  'title',
+  'content',
+  'createdTime',
+  'updatedTime',
+  'author',
+  'comments',
+];
 async function getOneArticle(ctx) {
-  // TODO
+  const { _id, title } = ctx.paramsData.article;
+  const dataToSend = _.pick(ctx.paramsData.article, articleAvailableProps);
+  recordAction(ctx, `查询文章 ${title} (_id = ${_id})`);
+  return sendData(ctx, dataToSend, 'OK', 'Got article information successfully');
 }
 
 async function updateOneArticle(ctx) {
-  // TODO
+  const { body } = ctx.request;
+  const {
+    user: { _id: curUserId, permission },
+    article: { _id, author, title },
+  } = ctx.paramsData;
+
+  if (String(curUserId) !== String(author) && permission !== 2) {
+    return sendData(ctx, {}, 'NO_PERMISSION', 'You cannot delete this article', 403);
+  }
+  if (!await isValidNewArticle(ctx, body)) return;
+
+  let result = null;
+  try {
+    result = await articleService.updateOne(_id, body);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  if (result.n !== 1) {
+    return sendData(ctx, {}, 'UPDATE_FAILURE', 'Failed to update the article', 500);
+  } else if (result.nModified !== 1) {
+    return sendData(ctx, {}, 'NOT_MODIFIED', 'Article not modified', 200);
+  }
+  const curTitle = body.title || title;
+  recordAction(ctx, `更新文章 ${curTitle} (_id = ${_id})`);
+  return sendData(ctx, {}, 'OK', `Updated article ${curTitle} successfully`);
 }
 
 async function commentOnArticle(ctx) {
-  // TODO
+  const { content } = ctx.request.body;
+  const {
+    user: { _id: author },
+    article: { _id: ownerId, title },
+  } = ctx.paramsData;
+
+  const newComment = {
+    author,
+    content,
+    type: 'article',
+    ownerId,
+  };
+
+  let _doc = null;
+  try {
+    _doc = await articleService.createOneComment(newComment);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  const { _id } = _doc;
+  recordAction(ctx, `评论文章 ${title} (articleId = ${ownerId}, commentId = ${_id})`);
+  return sendData(ctx, { _id }, 'OK', `Made comment on article ${title} successfully`);
 }
 
 module.exports = (router) => {

--- a/server/src/controllers/homework.js
+++ b/server/src/controllers/homework.js
@@ -1,7 +1,14 @@
 const Router = require('koa-router');
 const _ = require('lodash');
-const { sendData, handleError, recordAction } = require('../utils');
+const multer = require('../utils/multer');
+const {
+  sendData,
+  handleError,
+  recordAction,
+  isValidObjectId,
+} = require('../utils');
 const { debug, error } = require('../utils/logger');
+const userService = require('../service/user');
 const hwService = require('../service/homework');
 const authService = require('../service/authorization');
 
@@ -9,40 +16,181 @@ const hwRtr = new Router({
   prefix: '/hw',
 });
 
-hwRtr.post('/', authService.requireAdmin, createOneHomework);
-hwRtr.param('title', parseHomework);
-hwRtr.delete('/:title', authService.requireAdmin, deleteOneHomework);
-hwRtr.post('/:title', authService.requireLogin, handInOneHomework);
-hwRtr.post('/:title/comment/:userId', authService.requireAdmin, adminCommentOnOneUser);
+const upload = multer({
+  limits: {
+    fieldNameSize: 100,
+    fieldSize: 100,
+    fileSize: 10 * 1024 * 1024, // 10 Mib
+    fields: 5,
+    files: 5,
+    parts: 10,
+  },
+});
 
-async function parseHomework(title, ctx, next) {
+hwRtr.post('/',
+  authService.requireAdmin,
+  upload.array('attachment', 10),
+  createOneHomework
+);
+hwRtr.param('_id', parseHomework);
+hwRtr.param('userId', parseCommentedUser);
+hwRtr.get('/:_id', getOneHomework);
+hwRtr.delete('/:_id', authService.requireAdmin, deleteOneHomework);
+hwRtr.post('/:_id',
+  authService.requireLogin,
+  upload.single('submission'),
+  handInOneHomework
+);
+hwRtr.post('/:_id/comment/:userId', authService.requireAdmin, adminCommentOnOneUser);
+
+async function parseHomework(_id, ctx, next) {
+  if (!isValidObjectId(_id)) {
+    return sendData(ctx, {}, 'INVALID_VALUE', 'Invalid homework id', 400);
+  }
   let homework = null;
   try {
-    homework = await hwService.getOneHomework(title);
+    homework = await hwService.getOne(_id);
   } catch (e) {
     return handleError(ctx, e, 'DATABASE_QUERY_ERROR');
   }
   if (homework === null) {
     return sendData(ctx, {}, 'NOT_FOUND', 'Homework not found', 404);
   }
-  ctx.paramsData.homework = homework;
+  ctx.paramsData.homework = homework._doc;
   await next();
 }
 
-async function createOneHomework(ctx) {
+async function isValidNewHomework(ctx, newHw) {
   // TODO
+  return true;
 }
 
+async function createOneHomework(ctx, next) {
+  const { body, files } = ctx.request;
+  if (!await isValidNewHomework(ctx, body)) return;
+
+  let _doc = null;
+  try {
+    _doc = await hwService.createOne(body, files);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  const { title } = body;
+  const dataToSend = { _id: String(_doc._id), title };
+  recordAction(ctx, `创建作业 ${title} (_id = ${_doc._id})`);
+  return sendData(ctx, dataToSend, 'OK', `Created homework ${title} successfully`);
+}
+
+const hwAvailableProps = [
+  'title',
+  'description',
+  'beginTime',
+  'endTime',
+  'comments',
+];
+async function getOneHomework(ctx) {
+  const { _id, title } = ctx.paramsData.homework;
+  const dataToSend = _.pick(ctx.paramsData.homework, hwAvailableProps);
+  recordAction(ctx, `查询作业 ${title} (_id = ${_id})`);
+  return sendData(ctx, dataToSend, 'OK', 'Got homework information successfully');
+}
+
+
 async function deleteOneHomework(ctx) {
-  // TODO
+  const { _id, title } = ctx.paramsData.homework;
+  try {
+    await hwService.deleteOne(_id);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  recordAction(ctx, `删除作业 ${title} (_id = ${_id})`);
+  return sendData(ctx, {}, 'OK', `Deleted homework ${title} successfully`);
 }
 
 async function handInOneHomework(ctx) {
-  // TODO
+  const { _id: author } = ctx.session.user;
+  const { homework: { _id: hwId, title } } = ctx.paramsData;
+
+  if (!isAssignedHw(ctx.paramsData.user, hwId)) {
+    return sendData(ctx, {}, 'NOT_ASSIGNED', 'You are not assigned this homework', 403);
+  }
+
+  // 要提交的东西
+  const { file } = ctx.request;
+  const newSub = {
+    hwId,
+    author,
+    filename: file.originalname,
+  };
+
+  let _doc = null;
+  try {
+    _doc = await hwService.handInOne(newSub, file);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  const { _id } = _doc;
+  recordAction(ctx, `提交作业 ${title} (hwId = ${hwId}, subId = ${_id})`);
+  return sendData(ctx, { _id }, 'OK', `Submitted homework ${title} successfully`);
+
+  function isAssignedHw(user, hwId) {
+    return user.homeworks.some(oneHw => String(oneHw.hwId) === String(hwId));
+  }
+}
+
+async function parseCommentedUser(userId, ctx, next) {
+  if (!isValidObjectId(userId)) {
+    return sendData(ctx, {}, 'INVALID_VALUE', 'Invalid user id', 400);
+  }
+  const { homework: { _id: hwId } } = ctx.paramsData;
+  let commentedUser = null;
+  try {
+    commentedUser = await userService.getOneByIdAndHwId(userId, hwId);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_QUERY_ERROR');
+  }
+  debug.debug(commentedUser);
+  if (commentedUser === null) {
+    return sendData(ctx, {}, 'NOT_ASSIGNED', 'Homework not assigned to commented user', 403);
+  }
+  ctx.paramsData.commentedUser = commentedUser;
+  await next();
 }
 
 async function adminCommentOnOneUser(ctx) {
-  // TODO
+  const { content } = ctx.request.body;
+  const {
+    homework: { _id: queryedHwId, title },
+    commentedUser: { _id: author, username, homeworks },
+  } = ctx.paramsData;
+
+  let ownerId = null;
+  homeworks.some(({ hwId, subId }) => {
+    if (String(hwId) !== String(queryedHwId)) return false;
+    ownerId = subId;
+    return true;
+  });
+
+  const newComment = {
+    author,
+    content,
+    type: 'feedback',
+    ownerId,
+  };
+
+  let _doc = null;
+  try {
+    _doc = await hwService.createOneFeedback(newComment);
+  } catch (e) {
+    return handleError(ctx, e, 'DATABASE_UPDATE_ERROR');
+  }
+
+  const { _id } = _doc;
+  recordAction(ctx, `反馈用户 ${username} 的作业 ${title} (subId = ${ownerId}, commentId = ${_id})`);
+  return sendData(ctx, { _id }, 'OK', `Made feedback on homework ${title} successfully`);
 }
 
 module.exports = (router) => {

--- a/server/src/controllers/index.js
+++ b/server/src/controllers/index.js
@@ -20,8 +20,8 @@ const apiRtr = new Router({
 init(apiRtr);
 
 module.exports = () => compose([
-  getBodyParser(),
   convert(getSession()),
+  getBodyParser(),
   apiRtr.routes(),
   apiRtr.allowedMethods(),
   serve(config.static),
@@ -29,6 +29,7 @@ module.exports = () => compose([
 
 function getBodyParser() {
   return bodyParser({
+    formLimit: '10mb',
     jsonLimit: '10mb',
     textLimit: '10mb',
     async onerror(err, ctx) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -26,7 +26,11 @@ async function init() {
 
   app.use(controller());
 
-  app.on('error', (err, ctx) => handleError(ctx, err));
+  app.on('error', (err, ctx) => {
+    handleError(ctx, err);
+    err.expose = process.env.NODE_ENV !== 'production';
+    err.message = err.stack;
+  });
 
   app.listen(config.port, () => {
     serverStarted = true;

--- a/server/src/models/article.js
+++ b/server/src/models/article.js
@@ -30,6 +30,7 @@ const schema = {
     type: [{
       type: ObjectId,
       ref: 'comment',
+      required: true,
     }],
     default: [],
   },

--- a/server/src/models/comment.js
+++ b/server/src/models/comment.js
@@ -1,11 +1,12 @@
 const ObjectId = require('mongoose').Schema.Types.ObjectId;
 
 const schema = {
-  title: {
-    type: String,
+  author: {
+    type: ObjectId,
+    ref: 'user',
     required: true,
   },
-  content: {  // content
+  content: {
     type: String,
     required: true,
   },
@@ -17,21 +18,22 @@ const schema = {
     type: Date,
     default: null,
   },
-  author: {
-    type: ObjectId,
-    ref: 'user',
+  type: {
+    type: String,
     required: true,
   },
-  // username: {  // show in front end
-  //   type: String,
-  //   required: true,
-  // },
-  comments: {
-    type: [{
-      type: ObjectId,
-      ref: 'comment',
-    }],
-    default: [],
+  ownerId: {
+    type: ObjectId,
+    refPath: 'type',
+    required: true,
+  },
+  details: {
+    type: {
+      isFeedback: {
+        type: Boolean,
+      },
+    },
+    default: {},
   },
   deleted: {
     type: Boolean,

--- a/server/src/models/file.js
+++ b/server/src/models/file.js
@@ -1,0 +1,7 @@
+const GridFs = require('mongoose-gridfs');
+const Promise = require('bluebird');
+
+exports = module.exports = (db) => {
+  db.fs = GridFs().model;
+  Promise.promisifyAll(db.fs);
+};

--- a/server/src/models/homework.js
+++ b/server/src/models/homework.js
@@ -21,11 +21,16 @@ const schema = {
     type: [{
       type: ObjectId,
       ref: 'comment',
+      required: true,
     }],
     default: [],
   },
   attachments: {
-    type: [String],
+    type: [{
+      type: ObjectId,
+      ref: 'File',
+      required: true,
+    }],
     default: [],
   },
   deleted: {

--- a/server/src/models/index.js
+++ b/server/src/models/index.js
@@ -17,4 +17,6 @@ Object.keys(models).forEach((item) => {
   db[item] = mongoose.model(item, new mongoose.Schema(models[item].default));
 });
 
+require('./file')(db);
+
 module.exports = db;

--- a/server/src/models/submission.js
+++ b/server/src/models/submission.js
@@ -1,21 +1,27 @@
 const ObjectId = require('mongoose').Schema.Types.ObjectId;
 
 const schema = {
-  title: {
-    type: String,
+  hwId: {
+    type: ObjectId,
+    ref: 'homework',
     required: true,
   },
-  description: {
+  author: {
+    type: ObjectId,
+    ref: 'user',
+    required: true,
+  },
+  createdTime: {
+    type: Date,
+    default: Date.now,
+  },
+  updatedTime: {
+    type: Date,
+    default: null,
+  },
+  filename: {
     type: String,
-    default: '',
-  },
-  beginTime: {
-    type: Date,
-    default: null,
-  },
-  endTime: {
-    type: Date,
-    default: null,
+    required: true,
   },
   comments: {
     type: [{
@@ -24,8 +30,11 @@ const schema = {
     }],
     default: [],
   },
-  attachments: {
-    type: [String],
+  feedbacks: {
+    type: [{
+      type: ObjectId,
+      ref: 'comment',
+    }],
     default: [],
   },
   deleted: {

--- a/server/src/models/submission.js
+++ b/server/src/models/submission.js
@@ -19,14 +19,16 @@ const schema = {
     type: Date,
     default: null,
   },
-  filename: {
-    type: String,
+  fileId: {
+    type: ObjectId,
+    ref: 'File',
     required: true,
   },
   comments: {
     type: [{
       type: ObjectId,
       ref: 'comment',
+      required: true,
     }],
     default: [],
   },
@@ -34,6 +36,7 @@ const schema = {
     type: [{
       type: ObjectId,
       ref: 'comment',
+      required: true,
     }],
     default: [],
   },

--- a/server/src/models/user.js
+++ b/server/src/models/user.js
@@ -1,5 +1,7 @@
+const ObjectId = require('mongoose').Schema.Types.ObjectId;
+
 const schema = {
-  id: {  // login id
+  username: {
     type: String,
     required: true,
     unique: true,
@@ -12,19 +14,15 @@ const schema = {
     type: Number,
     default: 1,
     min: 1,
-    max: 3,
+    max: 3,  // 范围待定
   },
   nickname: {
     type: String,
-    default: 'nickname',
+    default: 'MIACer',
   },
   github: {  // Github link
     type: String,
     match: /(?:^$)|(?:^(?:https:\/\/){0,1}github\.com\/\S{1,})/,
-    default: '',
-  },
-  headimg: {  // link of head portrait
-    type: String,
     default: '',
   },
   email: {   // E-mail
@@ -32,28 +30,16 @@ const schema = {
     match: /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/,
     required: true,
   },
-  hw: {
+  homeworks: {
     type: [{  // Homeworks
-      title: {  // Homework's title
-        type: String,
+      hwId: {  // Homework's id
+        type: ObjectId,
+        ref: 'homework',
         required: true,
       },
-      file: {  // path to the file
-        type: String,
-        required: true,
-      },
-      comment: {  // comments
-        type: [{
-          text: {  // comment's content
-            type: String,
-            required: true,
-          },
-          author: {  // who comments
-            type: String,
-            required: true,
-          },
-        }],
-        default: [],
+      subId: {  // Latest submission's id
+        type: ObjectId,
+        ref: 'submission',
       },
     }],
     default: [],

--- a/server/src/service/article.js
+++ b/server/src/service/article.js
@@ -1,41 +1,47 @@
 const db = require('../models');
+const commentService = require('./comment');
 
 const article = db.article;
 
-async function createOneArticle(newArticle) {
-  return article.create(newArticle);
+async function getOne(_id) {
+  return article
+    .findOne({ _id, deleted: false })
+    .populate('comments')
+    .exec();
 }
 
-                              // articleId 是啥
-async function deleteOneArticle(articleId) {
-  return article.update(
-    { articleId, deleted: false },
+async function createOne(newArticle) {
+  Object.assign(newArticle, { createdTime: new Date() });
+  const { _doc } = await article.create(newArticle);
+  return _doc;
+}
+
+async function deleteOne(_id) {
+  const { _doc } = article.findOneAndUpdate(
+    { _id, deleted: false },
     { $set: { deleted: true } },
     { runValidators: true }
   ).exec();
+  return _doc;
 }
 
-async function getOneArticle(articleId) {
-  return article.find({ articleId, deleted: false }).exec();
-}
-
-async function updateOneArticle(articleId, newArticle) {
-  Object.assign(newArticle, { date: new Date() });
+async function updateOne(_id, newArticle) {
+  Object.assign(newArticle, { updatedTime: new Date() });
   return article.update(
-    { articleId, deleted: false },
+    { _id, deleted: false },
     { $set: newArticle },
     { runValidators: true }
   ).exec();
 }
 
-async function commentOnArticle() {
-  // TODO
+async function createOneComment(newComment) {
+  return commentService.createOne(newComment);
 }
 
 module.exports = {
-  createOneArticle,
-  deleteOneArticle,
-  getOneArticle,
-  updateOneArticle,
-  commentOnArticle,
+  getOne,
+  createOne,
+  deleteOne,
+  updateOne,
+  createOneComment,
 };

--- a/server/src/service/authorization.js
+++ b/server/src/service/authorization.js
@@ -13,8 +13,8 @@ async function requireLogin(ctx, next) {
 }
 
 async function requireAdmin(ctx, next) {
-  if (ctx.session.user.permission === 2) {  // 不知道是不是 2
-    return sendData(ctx, {}, 'NO_PERMISSION', 'Administrator authority required', 400);
+  if (ctx.session.user.permission !== 2) {  // 不知道是不是 2
+    return sendData(ctx, {}, 'NO_PERMISSION', 'Administrator authority required', 403);
   }
   await next();
 }

--- a/server/src/service/comment.js
+++ b/server/src/service/comment.js
@@ -1,0 +1,46 @@
+const db = require('../models');
+
+const comment = db.comment;
+const owner = {
+  article: db.article,
+  homework: db.homework,
+  submission: db.submission,
+  feedback: db.submission,
+};
+
+async function createOne(newComment) {
+  Object.assign(newComment, { createdTime: new Date() });
+  const { ownerId, type } = newComment;
+  const { _doc } = await comment.create(newComment);
+
+  const commentArr = (type === 'feedback' ? 'feedbacks' : 'comments');
+  // 为文章、提交等的评论数组 增加评论的 ObjectId
+  const result = await owner[type].update(
+    { _id: ownerId },
+    { $push: { [commentArr]: _doc._id } },
+    { runValidators: true }
+  ).exec();
+  return _doc;
+}
+
+async function deleteOne(_id) {
+  // 从 comments 中删除评论
+  const { _doc } = await comment.findOneAndUpdate(
+    { _id, deleted: false },
+    { $set: { deleted: true } },
+    { runValidators: true }
+  ).exec();
+  const { type, ownerId } = _doc;
+  // 从文章、提交等的评论数组 删除评论的 ObjectId
+  const result = await owner[type].update(
+    { _id: ownerId },
+    { $pull: { comments: _id } },
+    { runValidators: true }
+  ).exec();
+  return _doc;
+}
+
+module.exports = {
+  createOne,
+  deleteOne,
+};

--- a/server/src/service/file.js
+++ b/server/src/service/file.js
@@ -1,5 +1,47 @@
+const db = require('../models');
+const fs = db.fs;
+const Readable = require('stream').Readable;
+const Promise = require('bluebird');
+const { handleError } = require('../utils');
+const { debug, error } = require('../utils/logger');
 
+function getReadableStream(content) {
+  const readable = new Readable({ read() {} });
+  readable.push(content);
+  readable.push(null);
+  return readable;
+}
 
- exports = module.exports = {
+function handleFileServiceError(ctx, e) {
+  if (ctx === null) {
+    error.error('File Service Error :');
+    error.error(e);
+    return;
+  }
+  return handleError(ctx, e, 'FILE_SERVICE_ERROR', '文件服务错误'), false;
+}
 
- };
+async function uploadBinaryFiles(ctx, filesInfo) {
+  try {
+    return Promise.map(
+      filesInfo,
+      ({ filename, content }) => fs.writeAsync({ filename }, getReadableStream(content)),
+      { concurrency: 3 }
+    );
+  } catch (e) {
+    return handleFileServiceError(ctx, e);
+  }
+}
+
+async function downloadOneFile(ctx, id) {
+  try {
+    return fs.readById(id);
+  } catch (e) {
+    return handleFileServiceError(ctx, e);
+  }
+}
+
+exports = module.exports = {
+  uploadBinaryFiles,
+  downloadOneFile,
+};

--- a/server/src/service/file.js
+++ b/server/src/service/file.js
@@ -1,4 +1,4 @@
- // 怎么存取文件的函数
+
 
  exports = module.exports = {
 

--- a/server/src/service/homework.js
+++ b/server/src/service/homework.js
@@ -1,42 +1,60 @@
 const db = require('../models');
+const subService = require('./submission');
+const commentService = require('./comment');
 const fileService = require('./file');
 
 const homework = db.homework;
 const user = db.user;
 
-async function getOneHomework(title) {
-  return homework.find({ title, deleted: false }).exec();
+async function getOne(_id) {
+  return homework
+    .findOne({ _id, deleted: false })
+    .populate('comments')
+    .exec();
 }
 
-async function createOneHomework(newHomework) {
-  return homework.create(newHomework);
+async function createOne(newHw) {
+  const { _doc } = await homework.create(newHw);
+  // 顺便给每个人布置作业。以后应该会分开
+  await user.update(
+    { permission: 1 },  // 所有小朋友
+    { $push: { homeworks: { hwId: _doc._id } } },
+    { multi: true, runValidators: true }
+  ).exec();
+  return _doc;
 }
 
-async function deleteOneHomework(title) {
-  return homework.update(
-    { title, deleted: false },
+async function deleteOne(_id) {
+  // 从 homeworks 中删除作业
+  const { _doc } = await homework.findOneAndUpdate(
+    { _id, deleted: false },
     { $set: { deleted: true } },
     { runValidators: true }
   ).exec();
+
+  // 从 users 中删除每个人对该作业的 ObjectId
+  let result = await user.update(
+    { 'homeworks.hwId': _id, permission: 1 },
+    { $pull: { homeworks: { hwId: _id } } },
+    { multi: true, runValidators: true }
+  ).exec();
+  console.debug(result);
+  return _doc;
 }
 
-async function handInOneHomework(ctx) {
-  // TODO
+async function handInOne(...args) {
+  return subService.createOne(...args);
 }
 
-async function createOneComment() {
-  // TODO
-}
-
-async function getAllComments() {
-  // TODO
+async function createOneFeedback(newComment) {
+  newComment.details = Object.assign(newComment.details || {}, { isFeedback: true });
+  return commentService.createOne(newComment);
 }
 
 module.exports = {
-  getOneHomework,
-  createOneHomework,
-  deleteOneHomework,
-  handInOneHomework,
-  createOneComment,
-  getAllComments,
+  getOne,
+  createOne,
+  deleteOne,
+  handInOne,
+  createOneFeedback,
 };

--- a/server/src/service/homework.js
+++ b/server/src/service/homework.js
@@ -9,7 +9,7 @@ const user = db.user;
 async function getOne(_id) {
   return homework
     .findOne({ _id, deleted: false })
-    .populate('comments')
+    .populate('comments attachments')
     .exec();
 }
 
@@ -51,10 +51,32 @@ async function createOneFeedback(newComment) {
   return commentService.createOne(newComment);
 }
 
+async function uploadFiles(ctx, files) {
+  const filesInfo = files.map(({ originalname, buffer }) => ({
+    filename: originalname,
+    content: buffer,
+  }));
+  const result = await fileService.uploadBinaryFiles(ctx, filesInfo);
+  return result.map(({ _id }) => _id);
+}
+
+async function uploadOneFile(ctx, file) {
+  const ids = await uploadFiles(ctx, [file]);
+  if (!ids) return false;
+  return ids[0];
+}
+
+async function downloadOneFile(ctx, fileId) {
+  return fileService.downloadOneFile(ctx, fileId);
+}
+
 module.exports = {
   getOne,
   createOne,
   deleteOne,
   handInOne,
   createOneFeedback,
+  uploadFiles,
+  uploadOneFile,
+  downloadOneFile,
 };

--- a/server/src/service/submission.js
+++ b/server/src/service/submission.js
@@ -1,0 +1,52 @@
+const db = require('../models');
+const fileService = require('./file');
+
+const submission = db.submission;
+const user = db.user;
+
+async function getOne(_id) {
+  return submission
+    .find({ _id, deleted: false })
+    .populate('hwId author comments feedbacks')
+    .exec();
+}
+
+async function createOne(newSub, file) {
+  Object.assign(newSub, { createdTime: new Date() });
+  const { _doc } = await submission.create(newSub);
+  await user.update(
+    { _id: newSub.author, 'homeworks.hwId': newSub.hwId, permission: 1 },
+    { $set: { 'homeworks.$.subId': _doc._id } },
+    { runValidators: true }
+  ).exec();
+  return _doc;
+}
+
+async function deleteOne(_id) {
+  const theSub = await submission.findOneAndUpdate(
+    { _id, deleted: false },
+    { $set: { deleted: true } },
+    { runValidators: true }
+  ).exec();
+  return user.update(
+    { 'homeworks.subId': theSub._id, permission: 1 },
+    { $unset: { 'homeworks.$.subId': 1 } },
+    { runValidators: true }
+  ).exec();
+}
+
+async function updateOne(_id, newSub) {
+  Object.assign(newSub, { updatedTime: null });
+  await submission.findOneAndUpdate(
+    { _id, deleted: false },
+    { $set: newSub },
+    { runValidators: true }
+  ).exec();
+}
+
+module.exports = {
+  getOne,
+  createOne,
+  deleteOne,
+  updateOne,
+};

--- a/server/src/service/submission.js
+++ b/server/src/service/submission.js
@@ -37,7 +37,7 @@ async function deleteOne(_id) {
 
 async function updateOne(_id, newSub) {
   Object.assign(newSub, { updatedTime: null });
-  await submission.findOneAndUpdate(
+  return submission.update(
     { _id, deleted: false },
     { $set: newSub },
     { runValidators: true }

--- a/server/src/service/user.js
+++ b/server/src/service/user.js
@@ -2,24 +2,43 @@ const db = require('../models');
 
 const user = db.user;
 
-async function createOneUser(newUser) {
-  return user.create(newUser);
+async function createOne(newUser) {
+  const { _doc } = await user.create(newUser);
+  return _doc;
 }
 
-async function getOneUser(id) {
-  return user.findOne({ id, deleted: false }).exec();
+async function getOne(_id) {
+  return user
+    .findOne({ _id, deleted: false })
+    .populate('homeworks.hwId homeworks.subId')
+    .exec();
 }
 
-async function updateOneUser(id, newUser) {
+async function getOneByUsername(username) {
+  return user.findOne({ username, deleted: false }).exec();
+}
+
+async function getOneByIdAndHwId(_id, hwId) {
+  return user.findOne({
+    _id,
+    'homeworks.hwId': hwId,
+    'homeworks.subId': { $exists: true },
+    deleted: false,
+  }).exec();
+}
+
+async function updateOne(_id, newUser) {
   return user.update(
-    { id, deleted: false },
+    { _id, deleted: false },
     { $set: newUser },
     { runValidators: true }
   ).exec();
 }
 
 module.exports = {
-  createOneUser,
-  getOneUser,
-  updateOneUser,
+  createOne,
+  getOne,
+  getOneByUsername,
+  getOneByIdAndHwId,
+  updateOne,
 };

--- a/server/src/utils/multer.js
+++ b/server/src/utils/multer.js
@@ -1,0 +1,28 @@
+const koaMulter = require('koa-multer');
+const _ = require('lodash');
+const { sendData } = require('.');
+
+const funcs = ['any', 'array', 'fields', 'none', 'single'];
+
+function multer(...args) {
+  const upload = koaMulter(...args);
+  for (const oneFunc of funcs) {
+    wrapErrHandler(upload, oneFunc);
+  }
+  return upload;
+}
+
+function wrapErrHandler(upload, oneFunc) {
+  const uploadFunc = upload[oneFunc];
+  upload[oneFunc] = (...args) => async (ctx, next) => {
+    try {
+      await uploadFunc.call(upload, ...args)(ctx, () => {});
+    } catch (e) {
+      return sendData(ctx, {}, 'BAD_REQUEST', e.message, 400);
+    }
+    Object.assign(ctx.request, _.pick(ctx.req, ['body', 'file', 'files']));
+    return next();
+  };
+}
+
+module.exports = multer;


### PR DESCRIPTION
- 变成传递json和multipartform的RESTful服务端
- 改为更倾向于使用``ObjectId引用``的数据库结构（主要是很多元素都需要“修改”，直接嵌入不好改）
- 区分homework和submission的概念（但API路径仍然混用了这两个概念）
- 引入基于gridfs的文件服务
- 路径里的id全部换成ObjectId